### PR TITLE
fix: deinitialize codemirror on disconnect

### DIFF
--- a/src/wc-codemirror.js
+++ b/src/wc-codemirror.js
@@ -104,6 +104,12 @@ export class WCCodeMirror extends HTMLElement {
     this.__initialized = true
   }
 
+  disconnectedCallback() {
+    this.editor && this.editor.toTextArea()
+    this.editor = null
+    this.__initialized = false
+  }
+
   async setSrc () {
     const src = this.getAttribute('src')
     const contents = await this.fetchSrc(src)


### PR DESCRIPTION
Currently disconnecting and reconnecting an instance of `wc-codemirror` (such as lit-html does) causes a brand CodeMirror to initialise again and break the UI

This PR fixes the problem by destroying the editor instance when the element is disconnected